### PR TITLE
Support base64url encoding from JWT in Auth.

### DIFF
--- a/nexus-react/package-lock.json
+++ b/nexus-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-react",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/nexus-react/package.json
+++ b/nexus-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-react",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "React components for the nexus project",
   "main": "build/index.js",
   "license": "Apache-2.0",

--- a/nexus-react/src/components/Auth/store/actions.js
+++ b/nexus-react/src/components/Auth/store/actions.js
@@ -3,12 +3,21 @@ import * as types from "./types";
 
 const getLoginObjectFromURL = URL => {
   try {
+    // Token in JWT format
     const token = removeTokenFromUrl(URL);
     if (!token) { return {} }
+
+    // JWT structure is "base64url(header) . base64url(payload) . base64url(signature)"
     const [, payload, ] = token.split('.');
+
+    // Convert payload from base64url to plain base64.
+    // Only 2 characters differ.
+    const payloadBase64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+
+
     // Go through URL decoding to properly parse UTF-8 data.
     // @see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
-    const { name, exp } = JSON.parse(decodeURIComponent(escape(atob(payload))));
+    const { name, exp } = JSON.parse(decodeURIComponent(escape(atob(payloadBase64))));
     return { token, tokenExpiration: exp, tokenOwner: name }
   } catch (e) {
     console.error(e);

--- a/nexus-react/src/components/Auth/store/actions.js
+++ b/nexus-react/src/components/Auth/store/actions.js
@@ -14,7 +14,6 @@ const getLoginObjectFromURL = URL => {
     // Only 2 characters differ.
     const payloadBase64 = payload.replace(/-/g, '+').replace(/_/g, '/');
 
-
     // Go through URL decoding to properly parse UTF-8 data.
     // @see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
     const { name, exp } = JSON.parse(decodeURIComponent(escape(atob(payloadBase64))));


### PR DESCRIPTION
We only supported plain base64 payload, while JWT uses base64url, which differs by 2 characters.

If the JWT payload contains one of these 2 characters, it would fail to decode.

This commit adds proper support for base64url