### PR TITLE
Integrate to nexusweb as dependency

### DIFF
--- a/nexus-sdk-js/README.md
+++ b/nexus-sdk-js/README.md
@@ -6,3 +6,14 @@
 - Test: `npm run test`
 - Lint: `npm run lint`
 - Generate Documentation: `npm run documentation`
+
+## Usage
+
+```typescript
+import Nexus from 'nexus-sdk';
+
+const nexus: Nexus = new Nexus({
+  environment: 'http://api.url',
+  token: 'my_bearer_token',
+});
+```

--- a/nexus-sdk-js/package-lock.json
+++ b/nexus-sdk-js/package-lock.json
@@ -879,6 +879,15 @@
       "integrity": "sha512-Zh5Z4kACfbeE8aAOYh9mqotRxaZMro8MbBQtR8vEXOMiZo2rGEh2LayJijKdlu48YnS6y2EFU/oo2NCe5P6jGw==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.4.tgz",
+      "integrity": "sha512-tR1ekaXUGpmzOcDXWU9BW73YfA2/VW1DF1FH+wlJ82BbCSnWTbdX+JkqWQXWKIGsFPnPsYadbXfNgz28g+ccWg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/shelljs": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
@@ -5362,6 +5371,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7238,6 +7252,12 @@
         "tslint-eslint-rules": "^5.4.0",
         "tslint-microsoft-contrib": "~5.2.0"
       }
+    },
+    "tslint-config-prettier": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.16.0.tgz",
+      "integrity": "sha512-zu6RAcpBtqdvhT6KpBh9kRPYATjOf9BnRi718kNqVKFjEgSE4rFrPprFju1YJrkOa3RbtbWI1ZSuLd2NBX1MDw==",
+      "dev": true
     },
     "tslint-consistent-codestyle": {
       "version": "1.14.1",

--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -21,6 +21,7 @@
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
     "@types/jest": "^23.3.5",
+    "@types/node-fetch": "^2.1.4",
     "eslint": "^5.6.0",
     "jest": "^23.6.0",
     "rollup": "^0.66.4",
@@ -31,6 +32,7 @@
     "ts-jest": "^23.10.4",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.0",
+    "tslint-config-prettier": "^1.16.0",
     "typedoc": "^0.13.0",
     "typescript": "^3.0.3"
   },
@@ -58,6 +60,9 @@
   },
   "prettier": {
     "singleQuote": true,
-    "trailingComma": "es5"
+    "trailingComma": "all"
+  },
+  "dependencies": {
+    "node-fetch": "^2.3.0"
   }
 }

--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -2,10 +2,9 @@
   "name": "nexus-sdk",
   "version": "1.0.0",
   "description": "JavaScript SDK from Nexus",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "main": "lib/Nexus.js",
+  "module": "es/Nexus.js",
   "unpkg": "dist/nexus-sdk.js",
-  "types": "lib/index.d.ts",
   "license": "MIT",
   "scripts": {
     "test": "jest",
@@ -56,5 +55,9 @@
       "json",
       "node"
     ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "es5"
   }
 }

--- a/nexus-sdk-js/src/Nexus.ts
+++ b/nexus-sdk-js/src/Nexus.ts
@@ -1,5 +1,5 @@
 import Store from './utils/Store';
-import Organization, { OrganizationResponse } from './Organization';
+import Organization, { ListOrgsResponse, OrgInit } from './Organization';
 import { httpGet, httpPost } from './utils/http';
 
 type NexusConfig = {
@@ -20,7 +20,7 @@ export default class Nexus {
   constructor(config: NexusConfig) {
     if (!config.environment) {
       throw new Error(
-        'No environment provided. Please specify your Nexus instance endpoint.'
+        'No environment provided. Please specify your Nexus instance endpoint.',
       );
     }
     store.update('api', state => ({
@@ -49,31 +49,37 @@ export default class Nexus {
     }));
   }
 
+  // TODO: refactor -> blocked by https://github.com/BlueBrain/nexus/issues/112
+  // This is SUPER hacky.
+  // I first get the list of all projects which gives me a list of `_id` (that's because the /projects endpoint is not implemented either)
+  // I then generate an array of Orgs from the _id and return Orgs with empty everything, apart from name and @id.
   async listOrganizations(): Promise<Organization[]> {
     try {
-      const orgs: OrganizationResponse[] = await httpGet('/orgs');
-      return orgs.map((org: OrganizationResponse) => new Organization(org));
+      const listOrgsResponse: ListOrgsResponse = await httpGet('/projects');
+      if (listOrgsResponse.code || !listOrgsResponse._results) {
+        return [];
+      }
+      const filteredOrgs = listOrgsResponse._results
+        .map(org => org._id)
+        .filter((org, index, self) => self.indexOf(org) === index)
+        .map(org => ({
+          id: org,
+          name: org
+            .replace(`${store.getState().api.baseUrl}/projects/`, '')
+            .split('/')[0],
+        }));
+
+      const orgs = filteredOrgs.map(({ id, name }) => {
+        return new Organization({
+          '@context': listOrgsResponse['@context'],
+          '@id': id,
+          _label: name,
+        });
+      });
+      return orgs;
     } catch (e) {
       console.log(e);
-      return e;
-    }
-  }
-
-  async getOrganization(id: string): Promise<Organization> {
-    try {
-      const org: OrganizationResponse = await httpGet(`/orgs/${id}`);
-      return new Organization(org);
-    } catch (e) {
-      return e;
-    }
-  }
-
-  async createOrganization(): Promise<Organization> {
-    try {
-      const org: OrganizationResponse = await httpPost('/orgs', {});
-      return new Organization(org);
-    } catch (e) {
-      return e;
+      throw new Error(`ListOrgsError: ${e}`);
     }
   }
 }

--- a/nexus-sdk-js/src/Nexus.ts
+++ b/nexus-sdk-js/src/Nexus.ts
@@ -59,15 +59,23 @@ export default class Nexus {
       if (listOrgsResponse.code || !listOrgsResponse._results) {
         return [];
       }
+      // Close your eyes 😑
+      // map list and return only _id
+      // filter duplicates
+      // map to return list of {id, name}
       const filteredOrgs = listOrgsResponse._results
         .map(org => org._id)
         .filter((org, index, self) => self.indexOf(org) === index)
-        .map(org => ({
-          id: org,
-          name: org
-            .replace(`${store.getState().api.baseUrl}/projects/`, '')
-            .split('/')[0],
-        }));
+        .map(org => {
+          const idArray = org
+            .replace('/projects/', '/orgs/')
+            .split('/')
+            .slice(0, -1);
+          return {
+            id: idArray.join('/'),
+            name: idArray[idArray.length - 1],
+          };
+        });
 
       const orgs = filteredOrgs.map(({ id, name }) => {
         return new Organization({

--- a/nexus-sdk-js/src/Nexus.ts
+++ b/nexus-sdk-js/src/Nexus.ts
@@ -1,9 +1,5 @@
 import Store from './utils/Store';
-import Organization, {
-  ListOrgsResponse,
-  OrgInit,
-  OrgResponse,
-} from './Organization';
+import Organization, { ListOrgsResponse, OrgResponse } from './Organization';
 import { httpGet, httpPost } from './utils/http';
 
 type NexusConfig = {
@@ -61,7 +57,7 @@ export default class Nexus {
         return [];
       }
       // Get list of unique orgs names
-      const filteredOrgNames = listOrgsResponse._results
+      const filteredOrgNames: string[] = listOrgsResponse._results
         .map(org => {
           const split = org._id.split('/');
           const orgName = split.slice(split.length - 2, split.length - 1)[0];

--- a/nexus-sdk-js/src/Nexus.ts
+++ b/nexus-sdk-js/src/Nexus.ts
@@ -3,8 +3,8 @@ import Organization, { OrganizationResponse } from './Organization';
 import { httpGet, httpPost } from './utils/http';
 
 type NexusConfig = {
-  environment: string,
-  token: string,
+  environment: string;
+  token?: string;
 };
 
 export const store: Store = new Store({
@@ -18,13 +18,34 @@ export const store: Store = new Store({
 
 export default class Nexus {
   constructor(config: NexusConfig) {
-    store.update('auth', state => ({
-      ...state,
-      accessToken: config.token,
-    }));
+    if (!config.environment) {
+      throw new Error(
+        'No environment provided. Please specify your Nexus instance endpoint.'
+      );
+    }
     store.update('api', state => ({
       ...state,
       baseUrl: config.environment,
+    }));
+    if (config.token) {
+      store.update('auth', state => ({
+        ...state,
+        accessToken: config.token,
+      }));
+    }
+  }
+
+  setToken(token: string): void {
+    store.update('auth', state => ({
+      ...state,
+      accessToken: token,
+    }));
+  }
+
+  removeToken(): void {
+    store.update('auth', state => ({
+      ...state,
+      accessToken: undefined,
     }));
   }
 
@@ -33,6 +54,7 @@ export default class Nexus {
       const orgs: OrganizationResponse[] = await httpGet('/orgs');
       return orgs.map((org: OrganizationResponse) => new Organization(org));
     } catch (e) {
+      console.log(e);
       return e;
     }
   }

--- a/nexus-sdk-js/src/Organization.ts
+++ b/nexus-sdk-js/src/Organization.ts
@@ -1,20 +1,35 @@
 import { httpGet } from './utils/http';
 import Project, { ProjectResponse } from './Project';
 
-export type OrganizationResponse = {
+export interface ListOrgsResponse {
+  '@context': string;
+  _total: number;
+  _links?: string;
+  _results?: [{ _id: string }];
+  code?: string;
+  message?: string;
+}
+
+export interface OrgInit {
+  '@context': string;
   '@id': string;
-};
+  _label: string;
+}
 
 export default class Organization {
+  context: string;
   id: string;
+  label: string;
 
-  constructor(organizationResponse: OrganizationResponse) {
+  constructor(organizationResponse: OrgInit) {
+    this.context = organizationResponse['@context'];
     this.id = organizationResponse['@id'];
+    this.label = organizationResponse._label;
   }
 
   async listProjects(): Promise<Project[]> {
     try {
-      const projects = await httpGet(`/projects/${this.id}`);
+      const projects = await httpGet(`/projects/${this.label}`);
       return projects.map((project: ProjectResponse) => new Project(project));
     } catch (e) {
       return e;

--- a/nexus-sdk-js/src/Organization.ts
+++ b/nexus-sdk-js/src/Organization.ts
@@ -10,26 +10,41 @@ export interface ListOrgsResponse {
   message?: string;
 }
 
-export interface OrgInit {
+export interface OrgResponse {
   '@context': string;
   '@id': string;
-  _label: string;
+  '@type': string;
+  label: string;
+  name: string;
+  _deprecated: boolean;
+  _rev: number;
+  _uuid: string;
 }
 
 export default class Organization {
   context: string;
   id: string;
+  type: string;
   label: string;
+  name: string;
+  deprecated: boolean;
+  rev: number;
+  uuid: string;
 
-  constructor(organizationResponse: OrgInit) {
+  constructor(organizationResponse: OrgResponse) {
     this.context = organizationResponse['@context'];
     this.id = organizationResponse['@id'];
-    this.label = organizationResponse._label;
+    this.type = organizationResponse['@type'];
+    this.label = organizationResponse.label;
+    this.name = organizationResponse.name;
+    this.deprecated = organizationResponse._deprecated;
+    this.rev = organizationResponse._rev;
+    this.uuid = organizationResponse._uuid;
   }
 
   async listProjects(): Promise<Project[]> {
     try {
-      const projects = await httpGet(`/projects/${this.label}`);
+      const projects = await httpGet(`/projects/${this.name}`);
       return projects.map((project: ProjectResponse) => new Project(project));
     } catch (e) {
       return e;

--- a/nexus-sdk-js/src/utils/http.ts
+++ b/nexus-sdk-js/src/utils/http.ts
@@ -1,12 +1,17 @@
 import { store } from '../Nexus';
 
 const getHeaders = (headers?: Object): Headers => {
-  const { auth: { accessToken } } = store.getState();
-  if  (!accessToken) {
-    throw new Error('No access token found.');
+  const {
+    auth: { accessToken },
+  } = store.getState();
+  let extraHeaders = {};
+  if (accessToken) {
+    extraHeaders = {
+      Authorization: `Bearer ${accessToken}`,
+    };
   }
   return new Headers({
-    Authorization: `Bearer ${accessToken}`,
+    ...extraHeaders,
     mode: 'cors',
   });
 };
@@ -28,8 +33,10 @@ const parseError = (error: Error) => {
 };
 
 export function httpGet(url: string): Promise<any> {
-  const { api: { baseUrl } } = store.getState();
-  return fetch(`${baseUrl.getURL()}${url}`, {
+  const {
+    api: { baseUrl },
+  } = store.getState();
+  return fetch(`${baseUrl}${url}`, {
     headers: getHeaders(),
   })
     .then(checkStatus)
@@ -38,7 +45,9 @@ export function httpGet(url: string): Promise<any> {
 }
 
 export const httpPost = (url: string, body: Object): Promise<any> => {
-  const { api: { baseUrl } } = store.getState();
+  const {
+    api: { baseUrl },
+  } = store.getState();
   return fetch(`${baseUrl.getURL()}${url}`, {
     headers: getHeaders(),
     method: 'POST',

--- a/nexus-sdk-js/src/utils/http.ts
+++ b/nexus-sdk-js/src/utils/http.ts
@@ -1,6 +1,7 @@
+import fetch, { Headers, HeaderInit, Response } from 'node-fetch';
 import { store } from '../Nexus';
 
-const getHeaders = (headers?: Object): Headers => {
+const getHeaders = (headers?: Object): HeaderInit => {
   const {
     auth: { accessToken },
   } = store.getState();
@@ -48,7 +49,7 @@ export const httpPost = (url: string, body: Object): Promise<any> => {
   const {
     api: { baseUrl },
   } = store.getState();
-  return fetch(`${baseUrl.getURL()}${url}`, {
+  return fetch(`${baseUrl}${url}`, {
     headers: getHeaders(),
     method: 'POST',
   })

--- a/nexus-sdk-js/tsconfig.json
+++ b/nexus-sdk-js/tsconfig.json
@@ -1,30 +1,31 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     // "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": [                                  /* Specify library files to be included in the compilation. */
+    "lib": [
+      /* Specify library files to be included in the compilation. */
       "es2015",
       "dom"
-    ],                             
+    ],
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    "declarationMap": false,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
+    "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "lib",                        /* Redirect output structure to the directory. */
-    "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
+    "removeComments": true /* Do not emit comments to output. */,
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -39,14 +40,14 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -59,10 +60,5 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "exclude": [
-    "node_modules",
-    "es",
-    "lib",
-    "dist"
-  ]
+  "exclude": ["node_modules", "es", "lib", "dist"]
 }

--- a/nexus-sdk-js/tslint.json
+++ b/nexus-sdk-js/tslint.json
@@ -1,9 +1,9 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint-config-airbnb"
-    ],
-    "jsRules": {},
-    "rules": {},
-    "rulesDirectory": []
+  "defaultSeverity": "error",
+  "extends": ["tslint-config-airbnb", "tslint-config-prettier"],
+  "jsRules": {},
+  "rules": {
+    "import-name": false
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
fixes BlueBrain/nexus#296

You can now `import Nexus from 'nexus-sdk'` in an es project, or `require('nexus-sdk')` in a commonjs project.

The SDK is now universal (works in both Node and browser) thanks to `node-fetch`.

I've implemented a temporary `listOrgs` method as well.