### PR TITLE
Fix name of prepublishOnly npm script

### DIFF
--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -25,7 +25,7 @@
     "build:umd": "rollup -c",
     "documentation": "typedoc --out documentation/ --exclude \"**/*+(test|spec).ts\" src/",
     "clean": "rm -fr es/ && rm -fr dist/ && rm -fr lib/ && rm -fr documentation/",
-    "prepublish": "npm run clean && npm run test && npm run lint && npm run build"
+    "prepublishOnly": "npm run clean && npm run test && npm run lint && npm run build"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",


### PR DESCRIPTION
'prepublish' is deprecated. Replaced by 'prepublishOnly'.