### PR TITLE
add resource name property and tests

### DIFF
--- a/nexus-sdk-js/src/Resource/__tests__/Resource.spec.ts
+++ b/nexus-sdk-js/src/Resource/__tests__/Resource.spec.ts
@@ -132,4 +132,50 @@ describe('Resource class', () => {
       expect(resource.data.banana).toBeUndefined();
     });
   });
+
+  describe('.name', () => {
+    it('should match the name property if defined', () => {
+      const myName = 'Foo';
+      const resource = new Resource('testOrg', 'testProject', {
+        ...mockListResponseWithoutType,
+        name: myName,
+      });
+      expect(resource.name).toEqual(myName);
+    });
+    it('should match a schema:name property if defined', () => {
+      const myName = 'Foo';
+      const resource = new Resource('testOrg', 'testProject', {
+        ...mockListResponseWithoutType,
+        'schema:name': myName,
+      });
+      expect(resource.name).toEqual(myName);
+    });
+    it('should match a "skos:prefLabel" property if defined over "name"', () => {
+      const myName = 'Foo';
+      const myPrefLabel = 'Bar';
+      const resource = new Resource('testOrg', 'testProject', {
+        ...mockListResponseWithoutType,
+        'skos:prefLabel': myPrefLabel,
+        name: myName,
+      });
+      expect(resource.name).toEqual(myPrefLabel);
+    });
+    it('should efault to the @id value if nothing else matches', () => {
+      const resource = new Resource(
+        'testOrg',
+        'testProject',
+        mockListResponseWithoutType,
+      );
+      expect(resource.name).toEqual(mockListResponseWithoutType['@id']);
+    });
+    it('should return the overwritten value of .formatName() method', () => {
+      const bar = 'FooBar';
+      const resource = new Resource('testOrg', 'testProject', {
+        ...mockListResponseWithoutType,
+        foo: bar,
+      });
+      resource.formatName = resource => resource.foo;
+      expect(resource.name).toEqual(bar);
+    });
+  });
 });

--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -77,7 +77,7 @@ export default class Resource<T = {}> {
   deprecated: boolean;
   distribution?: Distribution | Distribution[];
   data: T;
-  raw: any;
+  raw: ResourceResponseCommon;
   constructor(
     orgLabel: string,
     projectLabel: string,
@@ -116,5 +116,19 @@ export default class Resource<T = {}> {
       },
       {},
     );
+  }
+
+  formatName(raw: ResourceResponseCommon): string {
+    const formattedNameValue =
+      raw['skos:prefLabel'] ||
+      raw['rdfs:label'] ||
+      raw['schema:name'] ||
+      raw['name'] ||
+      raw['@id'];
+    return formattedNameValue;
+  }
+
+  get name(): string {
+    return this.formatName(this.raw);
   }
 }

--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -123,6 +123,7 @@ export default class Resource<T = {}> {
       raw['skos:prefLabel'] ||
       raw['rdfs:label'] ||
       raw['schema:name'] ||
+      raw['label'] ||
       raw['name'] ||
       raw['@id'];
     return formattedNameValue;


### PR DESCRIPTION
# NEW
Adds a `name` getter to Resource

## Why?
It's needed for human-readable interfaces, as a way for us to reference resources without looking at UUIDs

## How to make it generic?
You can overwrite the `formatName` property to create your own UI-friendly Resource name, but the default behavior follows @MFSY's advice on where to get a semantically useful resource label for UI purposes. 