### PR TITLE
fix simple assingment bug

### DIFF
--- a/nexus-sdk-js/src/Project/utils.ts
+++ b/nexus-sdk-js/src/Project/utils.ts
@@ -17,7 +17,7 @@ export async function getProject(
 ): Promise<Project> {
   try {
     // check if we have options
-    let ops;
+    let ops: string = '';
     if (options) {
       // it's rev or tag, not both. We take rev over tag
       if (options.revision) {


### PR DESCRIPTION
There's a case where options in getProject is undefined and so opts returns undefined, making a bad URL to fetch the project. 