### PR TITLE
fix fetching all resources issue

### DIFF
--- a/nexus-sdk-js/package-lock.json
+++ b/nexus-sdk-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",

--- a/nexus-sdk-js/src/Project/index.ts
+++ b/nexus-sdk-js/src/Project/index.ts
@@ -82,37 +82,18 @@ export default class Project {
     pagination?: PaginationSettings,
   ): Promise<PaginatedList<Resource>> {
     try {
-      const requestURL = pagination
-        ? `${this.projectResourceURL}?from=${pagination.from}&size=${
-            pagination.size
-          }`
-        : this.projectResourceURL;
-
-      const listResourceResponses: ListResourceResponse = await httpGet(
-        requestURL,
-      );
-
-      const total: number = listResourceResponses._total;
-
-      // Expand the data for each item in the list
-      // By fetching each item by ID
-      const results: Resource[] = await Promise.all(
-        listResourceResponses._results.map(async resource => {
-          return await this.getResource(resource['_self']);
-        }),
-      );
-
-      return {
-        total,
-        results,
-      };
-    } catch (e) {
-      return e;
+      return await Resource.list(this.orgLabel, this.label, pagination);
+    } catch (error) {
+      throw error;
     }
   }
 
   async getResource(id: string): Promise<Resource> {
-    return await Resource.getSelf(id, this.orgLabel, this.label);
+    try {
+      return await Resource.getSelf(id, this.orgLabel, this.label);
+    } catch (error) {
+      throw error;
+    }
   }
 
   // The current API does not support pagination / filtering of views

--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -4,6 +4,7 @@ import {
   getSelfResource,
   updateResource,
   updateSelfResource,
+  listResources,
 } from './utils';
 
 export const RESOURCE_METADATA_KEYS = [
@@ -75,6 +76,7 @@ export default class Resource<T = {}> {
   static get = getResource;
   static updateSelf = updateSelfResource;
   static update = updateResource;
+  static list = listResources;
 
   static formatName(raw: ResourceResponseCommon): string {
     const formattedNameValue =

--- a/nexus-sdk-js/src/Resource/utils.ts
+++ b/nexus-sdk-js/src/Resource/utils.ts
@@ -58,18 +58,28 @@ export async function listResources(
 
     // Expand the data for each item in the list
     // By fetching each item by ID
-    const results: Resource[] = await Promise.all(
+    const allResults: (Resource | undefined)[] = await Promise.all(
       listResourceResponses._results.map(async resource => {
-        return await getSelfResource(resource['_self'], orgLabel, projectLabel);
+        try {
+          return await getSelfResource(
+            resource['_self'],
+            orgLabel,
+            projectLabel,
+          );
+        } catch (error) {
+          console.log(error);
+          return Promise.resolve(undefined);
+        }
       }),
     );
-
+    // @ts-ignore
+    const results: Resource[] = allResults.filter(r => r !== undefined) || [];
     return {
       total,
       results,
     };
-  } catch (e) {
-    return e;
+  } catch (error) {
+    throw error;
   }
 }
 
@@ -99,7 +109,7 @@ export async function updateSelfResource(
     );
     return new Resource(orgLabel, projectLabel, resourceResponse);
   } catch (error) {
-    throw new Error(error);
+    throw error;
   }
 }
 
@@ -128,6 +138,6 @@ export async function updateResource(
     );
     return new Resource(orgLabel, projectLabel, resourceResponse);
   } catch (error) {
-    throw new Error(error);
+    throw error;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus-explorer/pull/84

`Promise.all` returns everything or nothing. So because some resources return a 404 the whole thing was crashing.

I've made sure we handle errors a little better, return `Promise.resolve(undefined)` when there is a problem fetching a resource and finally filter out undefined resources. 

Also, I'm pointing at the static method `Resource.list` as there was some code duplication.