### PR TITLE
publishing 0.1.7 as 0.1.6 seems to have crashed somehow

### DIFF
--- a/nexus-sdk-js/package-lock.json
+++ b/nexus-sdk-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",


### PR DESCRIPTION
Looks like it works with 0.1.7 now. So apparently, the package-lock file need to be in sync, otherwise NPM does not complain, but everything is screwed. Might be a bug.