### PR TITLE
change resource payload

### DIFF
--- a/nexus-sdk-js/src/Resource/types.ts
+++ b/nexus-sdk-js/src/Resource/types.ts
@@ -21,6 +21,6 @@ export interface ResourceListTagResponse {
 export interface CreateResourcePayload {
   resourceId?: string;
   type?: string[];
-  context: { [field: string]: string };
+  context: { [field: string]: string } | any[];
   [field: string]: any;
 }


### PR DESCRIPTION
A simple change to the context type to reflect some example contexts I've seen in the wild, more specifically it better reflects now the default resources' contexts