### PR TITLE
Refactor/elasticsearch id name

### DIFF
--- a/nexus-sdk-js/package-lock.json
+++ b/nexus-sdk-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "JavaScript SDK from Nexus",
   "keywords": [
     "typescript",


### PR DESCRIPTION
Looks like there is a lot of changes but it's just because I have the prettier extension. We need to had this check as part of our build process, and maybe pre-commit hook.

main changes are package version and 

```typescript
const ES_DEFAULT_VIEW_ID: string = 'nxv:defaultElasticSearchIndex';
```

```typescript
const validTypes: string[] = [
    'ElasticSearchView',
    'AggregateElasticSearchView',
  ];
```
