### PR TITLE
Orgs and Projects events source

### DIFF
--- a/nexus-sdk-js/package-lock.json
+++ b/nexus-sdk-js/package-lock.json
@@ -817,6 +817,12 @@
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
+    "@types/eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-Ygc2l1zQRuuQL9WwE7BDn7M++X4JuHgJpSTrSo/CRt/Eao268rv4hpyv4H2TlZqQ1nYt/I4Wkwbpqg8Xjz5shA==",
+      "dev": true
+    },
     "@types/fs-extra": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
@@ -2258,6 +2264,14 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "requires": {
+        "original": "^1.0.0"
+      }
     },
     "exec-sh": {
       "version": "0.2.2",
@@ -5619,6 +5633,14 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -5929,6 +5951,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -6229,6 +6256,11 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.8.1",
@@ -7639,6 +7671,15 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",

--- a/nexus-sdk-js/package.json
+++ b/nexus-sdk-js/package.json
@@ -31,6 +31,7 @@
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
+    "@types/eventsource": "^1.1.0",
     "@types/jest": "^23.3.5",
     "@types/node-fetch": "^2.1.4",
     "eslint": "^5.6.0",
@@ -78,6 +79,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.0"
+    "cross-fetch": "^3.0.0",
+    "eventsource": "^1.0.7"
   }
 }

--- a/nexus-sdk-js/src/Organization/index.ts
+++ b/nexus-sdk-js/src/Organization/index.ts
@@ -5,6 +5,7 @@ import {
   listOrganizations,
   deprecateOrganization,
   updateOrganization,
+  subscribe,
 } from './utils';
 import { Context, CreateOrgPayload, OrgResponse } from './types';
 import { ListProjectOptions, CreateProjectPayload } from '../Project/types';
@@ -31,6 +32,7 @@ export default class Organization {
   static create = createOrganization;
   static update = updateOrganization;
   static deprecate = deprecateOrganization;
+  static subscribe = subscribe;
 
   constructor(organizationResponse: OrgResponse) {
     this.context = organizationResponse['@context'];

--- a/nexus-sdk-js/src/Organization/types.ts
+++ b/nexus-sdk-js/src/Organization/types.ts
@@ -39,3 +39,38 @@ export interface CreateOrgPayload {
   description?: string;
 }
 export type Context = string | string[];
+
+export enum OrgEventType {
+  OrgCreated = 'OrganizationCreated',
+  OrgUpdated = 'OrganizationUpdated',
+  OrgDeprecated = 'OrganizationDeprecated',
+}
+
+export interface OrgEvent {
+  '@context': Context;
+  '@type': OrgEventType;
+  description: string;
+  _instant: string;
+  _label: string;
+  _rev: number;
+  _subject: string;
+  _uuid: string;
+}
+
+export interface OrgCreatedEvent extends OrgEvent {
+  '@type': OrgEventType.OrgCreated;
+}
+export interface OrgUpdatedEvent extends OrgEvent {
+  '@type': OrgEventType.OrgUpdated;
+}
+export interface OrgDeprecatedEvent extends OrgEvent {
+  '@type': OrgEventType.OrgDeprecated;
+}
+
+export interface OrgEventListeners {
+  onOpen?(): void;
+  onError?(): void;
+  onOrgCreated?(event: OrgCreatedEvent): void;
+  onOrgUpdated?(event: OrgUpdatedEvent): void;
+  onOrgDeprecated?(event: OrgDeprecatedEvent): void;
+}

--- a/nexus-sdk-js/src/Organization/utils.ts
+++ b/nexus-sdk-js/src/Organization/utils.ts
@@ -15,6 +15,8 @@ import { httpPut, httpGet, httpDelete } from '../utils/http';
 import { CreateOrganizationException } from './exceptions';
 import { PaginatedList } from '../utils/types';
 import { getEventSource, parseMessageEventData } from '../utils/events';
+// @ts-ignore
+import EventSource = require('eventsource');
 
 /**
  *
@@ -145,9 +147,8 @@ export async function deprecateOrganization(
 
 export function subscribe(listeners: OrgEventListeners): EventSource {
   const event: EventSource = getEventSource('/orgs/events');
-  //
+
   // set event listeners
-  //
   listeners.onOpen && (event.onopen = listeners.onOpen);
   listeners.onError && (event.onerror = listeners.onError);
   listeners.onOrgCreated &&

--- a/nexus-sdk-js/src/Project/index.ts
+++ b/nexus-sdk-js/src/Project/index.ts
@@ -9,6 +9,7 @@ import {
   createProject,
   deprecateProject,
   updateProject,
+  subscribe,
 } from './utils';
 import {
   ApiMapping,
@@ -41,6 +42,7 @@ export default class Project {
   static create = createProject;
   static update = updateProject;
   static deprecate = deprecateProject;
+  static subscribe = subscribe;
 
   constructor(projectResponse: ProjectResponse) {
     this.context = projectResponse['@context'];

--- a/nexus-sdk-js/src/Project/types.ts
+++ b/nexus-sdk-js/src/Project/types.ts
@@ -58,8 +58,16 @@ export type ProjectEventType =
   | 'ProjectDeprecated';
 
 export interface ProjectEvent {
+  '@context': Context;
   '@type': ProjectEventType;
+  apiMappings: ApiMapping[];
+  base: string;
+  description: string;
+  vocab: string;
+  _instant: string;
   _label: string;
+  _rev: number;
+  _subject: string;
   _uuid: string;
 }
 
@@ -76,7 +84,7 @@ export interface ProjectDeprecatedEvent extends ProjectEvent {
 export interface ProjectEventListeners {
   onOpen?(): void;
   onError?(): void;
-  onProjectCreated?(): ProjectCreatedEvent;
-  onProjectUpdated?(): ProjectUpdatedEvent;
-  onProjectDeprecated?(): ProjectDeprecatedEvent;
+  onProjectCreated?(event: ProjectCreatedEvent): void;
+  onProjectUpdated?(event: ProjectUpdatedEvent): void;
+  onProjectDeprecated?(event: ProjectDeprecatedEvent): void;
 }

--- a/nexus-sdk-js/src/Project/types.ts
+++ b/nexus-sdk-js/src/Project/types.ts
@@ -52,10 +52,11 @@ export interface ListProjectOptions {
 
 export type Context = string | string[];
 
-export type ProjectEventType =
-  | 'ProjectCreated'
-  | 'ProjectUpdated'
-  | 'ProjectDeprecated';
+export enum ProjectEventType {
+  ProjectCreated = 'ProjectCreated',
+  ProjectUpdated = 'ProjectUpdated',
+  ProjectDeprecated = 'ProjectDeprecated',
+}
 
 export interface ProjectEvent {
   '@context': Context;
@@ -72,13 +73,13 @@ export interface ProjectEvent {
 }
 
 export interface ProjectCreatedEvent extends ProjectEvent {
-  '@type': 'ProjectCreated';
+  '@type': ProjectEventType.ProjectCreated;
 }
 export interface ProjectUpdatedEvent extends ProjectEvent {
-  '@type': 'ProjectCreated';
+  '@type': ProjectEventType.ProjectCreated;
 }
 export interface ProjectDeprecatedEvent extends ProjectEvent {
-  '@type': 'ProjectCreated';
+  '@type': ProjectEventType.ProjectCreated;
 }
 
 export interface ProjectEventListeners {

--- a/nexus-sdk-js/src/Project/types.ts
+++ b/nexus-sdk-js/src/Project/types.ts
@@ -51,3 +51,32 @@ export interface ListProjectOptions {
 }
 
 export type Context = string | string[];
+
+export type ProjectEventType =
+  | 'ProjectCreated'
+  | 'ProjectUpdated'
+  | 'ProjectDeprecated';
+
+export interface ProjectEvent {
+  '@type': ProjectEventType;
+  _label: string;
+  _uuid: string;
+}
+
+export interface ProjectCreatedEvent extends ProjectEvent {
+  '@type': 'ProjectCreated';
+}
+export interface ProjectUpdatedEvent extends ProjectEvent {
+  '@type': 'ProjectCreated';
+}
+export interface ProjectDeprecatedEvent extends ProjectEvent {
+  '@type': 'ProjectCreated';
+}
+
+export interface ProjectEventListeners {
+  onOpen?(): void;
+  onError?(): void;
+  onProjectCreated?(): ProjectCreatedEvent;
+  onProjectUpdated?(): ProjectUpdatedEvent;
+  onProjectDeprecated?(): ProjectDeprecatedEvent;
+}

--- a/nexus-sdk-js/src/Project/utils.ts
+++ b/nexus-sdk-js/src/Project/utils.ts
@@ -11,6 +11,7 @@ import {
   ProjectCreatedEvent,
   ProjectUpdatedEvent,
   ProjectDeprecatedEvent,
+  ProjectEventType,
 } from './types';
 import { PaginatedList } from '../utils/types';
 import { getEventSource, parseMessageEventData } from '../utils/events';
@@ -142,19 +143,19 @@ export function subscribe(listeners: ProjectEventListeners): EventSource {
   listeners.onOpen && (event.onopen = listeners.onOpen);
   listeners.onError && (event.onerror = listeners.onError);
   listeners.onProjectCreated &&
-    event.addEventListener('ProjectCreated', (event: Event) =>
+    event.addEventListener(ProjectEventType.ProjectCreated, (event: Event) =>
       parseMessageEventData<ProjectCreatedEvent>(event as MessageEvent)(
         listeners.onProjectCreated,
       ),
     );
   listeners.onProjectUpdated &&
-    event.addEventListener('ProjectUpdated', (event: Event) =>
+    event.addEventListener(ProjectEventType.ProjectUpdated, (event: Event) =>
       parseMessageEventData<ProjectUpdatedEvent>(event as MessageEvent)(
         listeners.onProjectUpdated,
       ),
     );
   listeners.onProjectDeprecated &&
-    event.addEventListener('ProjectDeprecated', (event: Event) =>
+    event.addEventListener(ProjectEventType.ProjectDeprecated, (event: Event) =>
       parseMessageEventData<ProjectDeprecatedEvent>(event as MessageEvent)(
         listeners.onProjectDeprecated,
       ),

--- a/nexus-sdk-js/src/Project/utils.ts
+++ b/nexus-sdk-js/src/Project/utils.ts
@@ -6,8 +6,10 @@ import {
   ProjectResponse,
   ListProjectsResponse,
   ProjectResponseCommon,
+  ProjectEventListeners,
 } from './types';
 import { PaginatedList } from '../utils/types';
+import { getEventSource } from '../utils/events';
 
 /**
  *
@@ -126,4 +128,18 @@ export async function deprecateProject(
   } catch (error) {
     throw new Error(error);
   }
+}
+
+export function subscribe(listeners: ProjectEventListeners): EventSource {
+  const event = getEventSource('/projects/event');
+  // set event listeners
+  listeners.onOpen && (event.onopen = listeners.onOpen);
+  listeners.onError && (event.onerror = listeners.onError);
+  listeners.onProjectCreated &&
+    event.addEventListener('ProjectCreated', listeners.onProjectCreated);
+  listeners.onProjectUpdated &&
+    event.addEventListener('ProjectUpdated', listeners.onProjectUpdated);
+  listeners.onProjectDeprecated &&
+    event.addEventListener('ProjectDeprecated', listeners.onProjectDeprecated);
+  return event;
 }

--- a/nexus-sdk-js/src/Project/utils.ts
+++ b/nexus-sdk-js/src/Project/utils.ts
@@ -7,9 +7,13 @@ import {
   ListProjectsResponse,
   ProjectResponseCommon,
   ProjectEventListeners,
+  ProjectEvent,
+  ProjectCreatedEvent,
+  ProjectUpdatedEvent,
+  ProjectDeprecatedEvent,
 } from './types';
 import { PaginatedList } from '../utils/types';
-import { getEventSource } from '../utils/events';
+import { getEventSource, parseMessageEventData } from '../utils/events';
 
 /**
  *
@@ -131,15 +135,30 @@ export async function deprecateProject(
 }
 
 export function subscribe(listeners: ProjectEventListeners): EventSource {
-  const event = getEventSource('/projects/event');
+  const event: EventSource = getEventSource('/projects/events');
+  //
   // set event listeners
+  //
   listeners.onOpen && (event.onopen = listeners.onOpen);
   listeners.onError && (event.onerror = listeners.onError);
   listeners.onProjectCreated &&
-    event.addEventListener('ProjectCreated', listeners.onProjectCreated);
+    event.addEventListener('ProjectCreated', (event: Event) =>
+      parseMessageEventData<ProjectCreatedEvent>(event as MessageEvent)(
+        listeners.onProjectCreated,
+      ),
+    );
   listeners.onProjectUpdated &&
-    event.addEventListener('ProjectUpdated', listeners.onProjectUpdated);
+    event.addEventListener('ProjectUpdated', (event: Event) =>
+      parseMessageEventData<ProjectUpdatedEvent>(event as MessageEvent)(
+        listeners.onProjectUpdated,
+      ),
+    );
   listeners.onProjectDeprecated &&
-    event.addEventListener('ProjectDeprecated', listeners.onProjectDeprecated);
+    event.addEventListener('ProjectDeprecated', (event: Event) =>
+      parseMessageEventData<ProjectDeprecatedEvent>(event as MessageEvent)(
+        listeners.onProjectDeprecated,
+      ),
+    );
+
   return event;
 }

--- a/nexus-sdk-js/src/Project/utils.ts
+++ b/nexus-sdk-js/src/Project/utils.ts
@@ -15,6 +15,8 @@ import {
 } from './types';
 import { PaginatedList } from '../utils/types';
 import { getEventSource, parseMessageEventData } from '../utils/events';
+// @ts-ignore
+import EventSource = require('eventsource');
 
 /**
  *
@@ -137,9 +139,8 @@ export async function deprecateProject(
 
 export function subscribe(listeners: ProjectEventListeners): EventSource {
   const event: EventSource = getEventSource('/projects/events');
-  //
+
   // set event listeners
-  //
   listeners.onOpen && (event.onopen = listeners.onOpen);
   listeners.onError && (event.onerror = listeners.onError);
   listeners.onProjectCreated &&

--- a/nexus-sdk-js/src/utils/events.ts
+++ b/nexus-sdk-js/src/utils/events.ts
@@ -1,6 +1,6 @@
+// @ts-ignore
+import EventSource = require('eventsource');
 import store from '../store';
-// tslint:disable-next-line:variable-name
-// const EventSource = require('eventsource');
 
 // TODO: speak to backend to figure out token
 const getHeaders = (): EventSourceInit => {

--- a/nexus-sdk-js/src/utils/events.ts
+++ b/nexus-sdk-js/src/utils/events.ts
@@ -1,20 +1,23 @@
 import store from '../store';
-const EventSource = require('eventsource');
+// tslint:disable-next-line:variable-name
+// const EventSource = require('eventsource');
 
 // TODO: speak to backend to figure out token
-const getHeaders = () => {
+const getHeaders = (): EventSourceInit => {
   const {
     auth: { accessToken },
   } = store.getState();
   let extraHeaders = {};
   if (accessToken) {
     extraHeaders = {
-      Authorization: `Bearer ${accessToken}`,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     };
   }
   return {
-    ...extraHeaders,
     withCredentials: true,
+    ...extraHeaders,
   };
 };
 
@@ -24,3 +27,9 @@ export function getEventSource(url: string): EventSource {
   } = store.getState();
   return new EventSource(baseUrl + url, getHeaders());
 }
+
+export const parseMessageEventData = <T>(
+  event: MessageEvent,
+): ((callback?: ((data: T) => void)) => void) => (
+  callback?: ((data: T) => void),
+): void => callback && callback(JSON.parse(event.data));

--- a/nexus-sdk-js/src/utils/events.ts
+++ b/nexus-sdk-js/src/utils/events.ts
@@ -1,0 +1,26 @@
+import store from '../store';
+const EventSource = require('eventsource');
+
+// TODO: speak to backend to figure out token
+const getHeaders = () => {
+  const {
+    auth: { accessToken },
+  } = store.getState();
+  let extraHeaders = {};
+  if (accessToken) {
+    extraHeaders = {
+      Authorization: `Bearer ${accessToken}`,
+    };
+  }
+  return {
+    ...extraHeaders,
+    withCredentials: true,
+  };
+};
+
+export function getEventSource(url: string): EventSource {
+  const {
+    api: { baseUrl },
+  } = store.getState();
+  return new EventSource(baseUrl + url, getHeaders());
+}


### PR DESCRIPTION
SO, you can now subscribe to Org and Project events:

```typescript
const eventSource = Project.subscribe({
  onProjectCreated: (projectCreated) => /* do whatever you want */,
  onProjectUpdated: (projectCreatedEvent) => /* ... */,
  onProjectDeprecated: (projectDeprecated) => /* ... */,
})
```

and the same for organisations:

```typescript
const eventSource = Organization.subscribe({
  onOrgCreated: (projectCreated) => /* do whatever you want */,
  onOrgUpdated: (projectCreatedEvent) => /* ... */,
  onOrgDeprecated: (projectDeprecated) => /* ... */,
})

// when your done
eventSource.close()
```

That means we can integrate this to nexus-web and get live notifications