### PR TITLE
👷‍♀️FIX: resource creation with URLs as IDs

### DIFF
--- a/nexus-sdk-js/src/Resource/__tests__/Resource.spec.ts
+++ b/nexus-sdk-js/src/Resource/__tests__/Resource.spec.ts
@@ -315,6 +315,48 @@ describe('Resource class', () => {
       );
     });
 
+    it('should PUT the new resource with an ID', async () => {
+      const payload: CreateResourcePayload = {
+        context: {
+          name: 'http://schema.org/name',
+          description: 'http://schema.org/description',
+        },
+        resourceId: 'myID',
+      };
+
+      createResource('myorg', 'myproject', 'myschema', payload);
+
+      expect(mock.calls[0][0]).toEqual(
+        `${baseUrl}/resources/myorg/myproject/myschema/myID`,
+      );
+      expect(mock.calls[0][1].method).toEqual('PUT');
+      expect(mock.calls[0][1].body).toEqual(
+        JSON.stringify({ '@context': payload.context }),
+      );
+    });
+
+    it('should PUT a resource with resourceID with URIencoded URL', async () => {
+      const payload: CreateResourcePayload = {
+        context: {
+          name: 'http://schema.org/name',
+          description: 'http://schema.org/description',
+        },
+        resourceId: 'https://mywebsite.com',
+      };
+
+      createResource('myorg', 'myproject', 'myschema', payload);
+
+      expect(mock.calls[0][0]).toEqual(
+        `${baseUrl}/resources/myorg/myproject/myschema/${encodeURIComponent(
+          'https://mywebsite.com',
+        )}`,
+      );
+      expect(mock.calls[0][1].method).toEqual('PUT');
+      expect(mock.calls[0][1].body).toEqual(
+        JSON.stringify({ '@context': payload.context }),
+      );
+    });
+
     it('should POST the new resource with the expected payload', async () => {
       const payload: CreateResourcePayload = {
         context: {

--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -29,15 +29,6 @@ export const RESOURCE_METADATA_KEYS = [
   '_deprecated',
 ];
 
-const isValidUrl = (string: string) => {
-  try {
-    new URL(string);
-    return true;
-  } catch (_) {
-    return false;
-  }
-};
-
 export default class Resource<T = {}> {
   readonly orgLabel: string;
   readonly projectLabel: string;

--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -29,6 +29,15 @@ export const RESOURCE_METADATA_KEYS = [
   '_deprecated',
 ];
 
+const isValidUrl = (string: string) => {
+  try {
+    new URL(string);
+    return true;
+  } catch (_) {
+    return false;
+  }
+};
+
 export default class Resource<T = {}> {
   readonly orgLabel: string;
   readonly projectLabel: string;

--- a/nexus-sdk-js/src/Resource/utils.ts
+++ b/nexus-sdk-js/src/Resource/utils.ts
@@ -102,7 +102,9 @@ export async function createResource(
     } else {
       const { context, type, resourceId, ...rest } = payload;
       const resourceResponse: ResourceResponse = await httpPut(
-        `/resources/${orgLabel}/${projectLabel}/${schemaId}/${resourceId}`,
+        `/resources/${orgLabel}/${projectLabel}/${schemaId}/${encodeURIComponent(
+          resourceId,
+        )}`,
         {
           '@context': context,
           '@type': type,


### PR DESCRIPTION
This fixes a problem where if you created a resource with an `@id` that is like a URL, for example `https://mywebsite.com`, it would not encode that URL when making the PUT request.
