### PR TITLE
👷‍♀️FIX: accept headers

### DIFF
--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -70,7 +70,6 @@ export default class Resource<T = {}> {
       // TODO move to File Class ?
       raw['_filename'] ||
       raw['@id'];
-    console.log({ name, raw });
     return name;
   }
 

--- a/nexus-sdk-js/src/Resource/index.ts
+++ b/nexus-sdk-js/src/Resource/index.ts
@@ -61,14 +61,17 @@ export default class Resource<T = {}> {
   static listTags = listTags;
   static listSelfTags = listSelfTags;
   static formatName(raw: ResourceResponse): string {
-    return (
+    const name =
       raw['skos:prefLabel'] ||
       raw['rdfs:label'] ||
       raw['schema:name'] ||
       raw['label'] ||
       raw['name'] ||
-      raw['@id']
-    );
+      // TODO move to File Class ?
+      raw['_filename'] ||
+      raw['@id'];
+    console.log({ name, raw });
+    return name;
   }
 
   constructor(

--- a/nexus-sdk-js/src/utils/__tests__/http.spec.ts
+++ b/nexus-sdk-js/src/utils/__tests__/http.spec.ts
@@ -27,7 +27,11 @@ describe('http module', () => {
       mockResponse('{}');
       httpGet('/service');
       expect(mock.calls[0][1].headers).toEqual(
-        new Headers({ 'Content-Type': 'application/json', mode: 'cors' }),
+        new Headers({
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          mode: 'cors',
+        }),
       );
     });
     it('should successfully parse JSON', async () => {

--- a/nexus-sdk-js/src/utils/http.ts
+++ b/nexus-sdk-js/src/utils/http.ts
@@ -10,7 +10,10 @@ interface HttpConfig {
 }
 
 const getHeaders = (
-  headers: { [key: string]: string } = { 'Content-Type': 'application/json' },
+  headers: { [key: string]: string } = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
 ): Headers => {
   const {
     auth: { accessToken },
@@ -43,14 +46,6 @@ function jsonParser(response: Response): Promise<Object> {
   }
 }
 
-function textParser(response: Response): Promise<string> {
-  try {
-    return response.text();
-  } catch (error) {
-    throw new Error(error.message);
-  }
-}
-
 function prepareBody<T = object>(body: T, as: httpTypes = 'json'): any {
   switch (as) {
     case 'text':
@@ -66,11 +61,6 @@ const parseResponse = (response: Response, parser = jsonParser): any => {
   } catch (error) {
     throw new Error(error.message);
   }
-};
-
-const parseJsonError = async (error: Response): Promise<JSON> => {
-  const payload: JSON = await error.json();
-  return payload;
 };
 
 export function httpGet(url: string, useBase: boolean = true): Promise<any> {


### PR DESCRIPTION
Because `Files` are now possible to fetch, we need to make the default for HTTP get to `Accept: application/json` otherwise when we try to list resources the SDK would fetch the actual files. 

